### PR TITLE
Make MySQL 8.0 build internally inside Facebook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,10 @@ ENDIF()
 # Maintainer mode is default on only for debug builds using GCC/G++
 IF(CMAKE_BUILD_TYPE MATCHES "Debug" OR WITH_DEBUG)
   IF(CMAKE_COMPILER_IS_GNUCC AND CMAKE_COMPILER_IS_GNUCXX)
-    SET(MYSQL_MAINTAINER_MODE ON CACHE BOOL
-        "MySQL maintainer-specific development environment")
+    IF(DEFINED FACEBOOK_INTERNAL AND NOT "${FACEBOOK_INTERNAL}" MATCHES "1")
+      SET(MYSQL_MAINTAINER_MODE ON CACHE BOOL
+          "MySQL maintainer-specific development environment")
+    ENDIF()
   ENDIF()
 ENDIF()
 

--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -151,12 +151,21 @@ MACRO (MYSQL_CHECK_SSL)
       LIST(REVERSE CMAKE_FIND_LIBRARY_SUFFIXES)
       MESSAGE(STATUS "suffixes <${CMAKE_FIND_LIBRARY_SUFFIXES}>")
     ENDIF()
-    FIND_LIBRARY(OPENSSL_LIBRARY
-                 NAMES ssl ssleay32 ssleay32MD
-                 HINTS ${OPENSSL_ROOT_DIR}/lib)
-    FIND_LIBRARY(CRYPTO_LIBRARY
-                 NAMES crypto libeay32
-                 HINTS ${OPENSSL_ROOT_DIR}/lib)
+    IF(DEFINED FACEBOOK_INTERNAL AND "${FACEBOOK_INTERNAL}" MATCHES "1")
+      FIND_LIBRARY(OPENSSL_LIBRARY
+                   NAMES ssl_pic ssl ssleay32 ssleay32MD
+                   HINTS ${OPENSSL_ROOT_DIR}/lib)
+      FIND_LIBRARY(CRYPTO_LIBRARY
+                   NAMES crypto_pic crypto libeay32
+                   HINTS ${OPENSSL_ROOT_DIR}/lib)
+    ELSE()
+      FIND_LIBRARY(OPENSSL_LIBRARY
+                   NAMES ssl ssleay32 ssleay32MD
+                   HINTS ${OPENSSL_ROOT_DIR}/lib)
+      FIND_LIBRARY(CRYPTO_LIBRARY
+                   NAMES crypto libeay32
+                   HINTS ${OPENSSL_ROOT_DIR}/lib)
+    ENDIF()
     IF (WITH_SSL_PATH)
       LIST(REVERSE CMAKE_FIND_LIBRARY_SUFFIXES)
     ENDIF()
@@ -173,14 +182,23 @@ MACRO (MYSQL_CHECK_SSL)
       OPENSSL_MAJOR_VERSION "${OPENSSL_VERSION_NUMBER}"
     )
 
-    IF(OPENSSL_INCLUDE_DIR AND
-       OPENSSL_LIBRARY   AND
-       CRYPTO_LIBRARY      AND
-       OPENSSL_MAJOR_VERSION STREQUAL "1"
-      )
-      SET(OPENSSL_FOUND TRUE)
+    IF(DEFINED FACEBOOK_INTERNAL AND "${FACEBOOK_INTERNAL}" MATCHES "1")
+      IF(OPENSSL_INCLUDE_DIR AND
+         OPENSSL_LIBRARY AND
+         CRYPTO_LIBRARY)
+        SET(OPENSSL_FOUND TRUE)
+       ELSE()
+        SET(OPENSSL_FOUND FALSE)
+      ENDIF()
     ELSE()
-      SET(OPENSSL_FOUND FALSE)
+      IF(OPENSSL_INCLUDE_DIR AND
+         OPENSSL_LIBRARY AND
+         CRYPTO_LIBRARY AND
+         OPENSSL_MAJOR_VERSION STREQUAL "1")
+        SET(OPENSSL_FOUND TRUE)
+       ELSE()
+        SET(OPENSSL_FOUND FALSE)
+      ENDIF()
     ENDIF()
 
     # If we are invoked with -DWITH_SSL=/path/to/custom/openssl

--- a/mysys_ssl/my_aes_openssl.cc
+++ b/mysys_ssl/my_aes_openssl.cc
@@ -49,6 +49,7 @@ const char *my_aes_opmode_names[]=
   "aes-128-cbc",
   "aes-192-cbc",
   "aes-256-cbc",
+#ifndef OPENSSL_IS_BORINGSSL
   "aes-128-cfb1",
   "aes-192-cfb1",
   "aes-256-cfb1",
@@ -61,6 +62,7 @@ const char *my_aes_opmode_names[]=
   "aes-128-ofb",
   "aes-192-ofb",
   "aes-256-ofb",
+#endif
   NULL /* needed for the type enumeration */
 };
 
@@ -77,6 +79,7 @@ static uint my_aes_opmode_key_sizes_impl[]=
   128 /* aes-128-cfb1 */,
   192 /* aes-192-cfb1 */,
   256 /* aes-256-cfb1 */,
+#ifndef OPENSSL_IS_BORINGSSL
   128 /* aes-128-cfb8 */,
   192 /* aes-192-cfb8 */,
   256 /* aes-256-cfb8 */,
@@ -86,6 +89,7 @@ static uint my_aes_opmode_key_sizes_impl[]=
   128 /* aes-128-ofb */,
   192 /* aes-192-ofb */,
   256 /* aes-256-ofb */
+#endif
 };
 
 uint *my_aes_opmode_key_sizes= my_aes_opmode_key_sizes_impl;
@@ -98,23 +102,25 @@ aes_evp_type(const my_aes_opmode mode)
   switch (mode)
   {
   case my_aes_128_ecb:    return EVP_aes_128_ecb();
+  case my_aes_192_ecb:    return EVP_aes_192_ecb();
+  case my_aes_256_ecb:    return EVP_aes_256_ecb();
   case my_aes_128_cbc:    return EVP_aes_128_cbc();
+  case my_aes_192_cbc:    return EVP_aes_192_cbc();
+  case my_aes_256_cbc:    return EVP_aes_256_cbc();
+#ifndef OPENSSL_IS_BORINGSSL
   case my_aes_128_cfb1:   return EVP_aes_128_cfb1();
   case my_aes_128_cfb8:   return EVP_aes_128_cfb8();
   case my_aes_128_cfb128: return EVP_aes_128_cfb128();
   case my_aes_128_ofb:    return EVP_aes_128_ofb();
-  case my_aes_192_ecb:    return EVP_aes_192_ecb();
-  case my_aes_192_cbc:    return EVP_aes_192_cbc();
   case my_aes_192_cfb1:   return EVP_aes_192_cfb1();
   case my_aes_192_cfb8:   return EVP_aes_192_cfb8();
   case my_aes_192_cfb128: return EVP_aes_192_cfb128();
   case my_aes_192_ofb:    return EVP_aes_192_ofb();
-  case my_aes_256_ecb:    return EVP_aes_256_ecb();
-  case my_aes_256_cbc:    return EVP_aes_256_cbc();
   case my_aes_256_cfb1:   return EVP_aes_256_cfb1();
   case my_aes_256_cfb8:   return EVP_aes_256_cfb8();
   case my_aes_256_cfb128: return EVP_aes_256_cfb128();
   case my_aes_256_ofb:    return EVP_aes_256_ofb();
+#endif
   default: return NULL;
   }
 }
@@ -143,7 +149,7 @@ int my_aes_encrypt(const unsigned char *source, uint32 source_length,
   if (!EVP_EncryptUpdate(&ctx, dest, &u_len, source, source_length))
     goto aes_error;                             /* Error */
 
-  if (!EVP_EncryptFinal(&ctx, dest + u_len, &f_len))
+  if (!EVP_EncryptFinal_ex(&ctx, dest + u_len, &f_len))
     goto aes_error;                             /* Error */
 
   EVP_CIPHER_CTX_cleanup(&ctx);

--- a/rapid/plugin/group_replication/libmysqlgcs/configure.cmake
+++ b/rapid/plugin/group_replication/libmysqlgcs/configure.cmake
@@ -40,10 +40,14 @@ ENDIF()
 # XDR related checks
 #
 
-IF (WIN32)
+IF (WIN32 OR DEFINED FACEBOOK_INTERNAL AND "${FACEBOOK_INTERNAL}" MATCHES "1")
   # On windows we bundle the rpc header and some code as well
   SET (CMAKE_REQUIRED_INCLUDES ${XCOM_BASEDIR}/windeps/sunrpc
                                ${XCOM_BASEDIR}/windeps/include)
+ENDIF()
+
+IF (DEFINED FACEBOOK_INTERNAL AND "${FACEBOOK_INTERNAL}" MATCHES "1")
+  include_directories(${XCOM_BASEDIR}/windeps/sunrpc)
 ENDIF()
 
 IF (NOT WIN32)

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -3386,7 +3386,10 @@ public:
   RSA *operator()(void)
   {
     /* generate RSA keys */
-    RSA *rsa= RSA_generate_key(m_key_size, m_exponent, NULL, NULL);
+    RSA *rsa= NULL;
+    BIGNUM *bne= NULL;
+    BN_set_word(bne, m_exponent);
+    RSA_generate_key_ex(rsa, m_key_size, bne, NULL);
     return rsa; // pass ownership
   }
 

--- a/sql/des_key_file.cc
+++ b/sql/des_key_file.cc
@@ -86,7 +86,7 @@ load_des_key_file(const char *file_name)
 
       if (start != end)
       {
-	DES_cblock ivec;
+	unsigned char ivec[8];
 	memset(&ivec, 0, sizeof(ivec));
 	// We make good 24-byte (168 bit) key from given plaintext key with MD5
 	EVP_BytesToKey(EVP_des_ede3_cbc(),EVP_md5(),NULL,

--- a/vio/viossl.cc
+++ b/vio/viossl.cc
@@ -432,7 +432,11 @@ static int ssl_do(struct st_VioSSLFd *ptr, Vio *vio, long timeout,
 
 #if !defined(HAVE_YASSL) && !defined(DBUG_OFF)
   {
+#ifndef OPENSSL_IS_BORINGSSL
     STACK_OF(SSL_COMP) *ssl_comp_methods = NULL;
+#else
+    COMP_METHOD *ssl_comp_methods = NULL;
+#endif
     ssl_comp_methods = SSL_COMP_get_compression_methods();
     n= sk_SSL_COMP_num(ssl_comp_methods);
     DBUG_PRINT("info", ("Available compression methods:\n"));


### PR DESCRIPTION
There are two categories of changes here:

 - Modifications in build enviornment and CMake rules. These changes
   are guarded by `FACEBOOK_INTERNAL` to make sure that we won't change
   the way how MySQL 8.0 is built outside internal Facebook environment.

 - Pure code. The code will diverge "By Design" and will be same for all
   types of build environments and there's no separation here.