### PR TITLE
Incremental work to make MyRocks build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Arcanist cache
+ /arcanist/.phutil_module_cache
+
+# Internal Facebook build puts generate files in directories like:
+/_build-8.0*
+
+# Internal Facebook Howtoeven static analyzer uses this directory.
+/.howtoeven/*
+
+# Files used in Facebook's internal testing system
+/.arcrc
+
 *-t
 *_test
 *.Plo

--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -32,9 +32,15 @@ ENDMACRO()
 # Common flags for all versions/compilers
 #
 
+IF(DEFINED FACEBOOK_INTERNAL AND "${FACEBOOK_INTERNAL}" MATCHES "1")
+  SET(MY_WARNING_FLAGS "")
+ELSE()
+  SET(MY_WARNING_FLAGS "-Wundef")
+ENDIF()
+
 # Common warning flags for GCC, G++, Clang and Clang++
 SET(MY_WARNING_FLAGS
-    "-Wall -Wextra -Wformat-security -Wvla -Wmissing-format-attribute -Wundef")
+    "${MY_WARNING_FLAGS} -Wall -Wextra -Wformat-security -Wvla -Wmissing-format-attribute")
 
 # Common warning flags for GCC and Clang
 SET(MY_C_WARNING_FLAGS

--- a/include/my_io_perf.h
+++ b/include/my_io_perf.h
@@ -1,0 +1,143 @@
+/* Copyright (c) 2016, Percona and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef _io_perf_h_
+#define _io_perf_h_
+
+#include "atomic_stat.h"
+#include <algorithm>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/* Per-table operation and IO statistics */
+
+/* Struct used for IO performance counters within a single thread */
+struct my_io_perf_struct {
+  ulonglong bytes;
+  ulonglong requests;
+  ulonglong svc_time; /*!< time to do read or write operation */
+  ulonglong svc_time_max;
+  ulonglong wait_time; /*!< total time in the request array */
+  ulonglong wait_time_max;
+  ulonglong slow_ios; /*!< requests that take too long */
+
+  /* Initialize a my_io_perf_t struct. */
+  inline void init() {
+    memset(this, 0, sizeof(*this));
+  }
+
+  /* Sets this to a - b in diff */
+  inline void diff(const my_io_perf_struct& a, const my_io_perf_struct& b) {
+    if (a.bytes > b.bytes)
+      bytes = a.bytes - b.bytes;
+    else
+      bytes = 0;
+
+    if (a.requests > b.requests)
+      requests = a.requests - b.requests;
+    else
+      requests = 0;
+
+    if (a.svc_time > b.svc_time)
+      svc_time = a.svc_time - b.svc_time;
+    else
+      svc_time = 0;
+
+    if (a.wait_time > b.wait_time)
+      wait_time = a.wait_time - b.wait_time;
+    else
+      wait_time = 0;
+
+    if (a.slow_ios > b.slow_ios)
+      slow_ios = a.slow_ios - b.slow_ios;
+    else
+      slow_ios = 0;
+
+    svc_time_max = std::max(a.svc_time_max, b.svc_time_max);
+    wait_time_max = std::max(a.wait_time_max, b.wait_time_max);
+  }
+
+  /* Accumulates io perf values */
+  inline void sum(const my_io_perf_struct& that) {
+    bytes += that.bytes;
+    requests += that.requests;
+    svc_time += that.svc_time;
+    svc_time_max = std::max(svc_time_max, that.svc_time_max);
+    wait_time += that.wait_time;
+    wait_time_max = std::max(wait_time_max, that.wait_time_max);
+    slow_ios += that.slow_ios;
+  }
+};
+typedef struct my_io_perf_struct my_io_perf_t;
+
+/* Struct used for IO performance counters, shared among multiple threads */
+struct my_io_perf_atomic_struct {
+  atomic_stat<ulonglong> bytes;
+  atomic_stat<ulonglong> requests;
+  atomic_stat<ulonglong> svc_time; /*!< time to do read or write operation */
+  atomic_stat<ulonglong> svc_time_max;
+  atomic_stat<ulonglong> wait_time; /*!< total time in the request array */
+  atomic_stat<ulonglong> wait_time_max;
+  atomic_stat<ulonglong> slow_ios; /*!< requests that take too long */
+
+  /* Initialize an my_io_perf_atomic_t struct. */
+  inline void init() {
+    bytes.clear();
+    requests.clear();
+    svc_time.clear();
+    svc_time_max.clear();
+    wait_time.clear();
+    wait_time_max.clear();
+    slow_ios.clear();
+  }
+
+  /* Accumulates io perf values using atomic operations */
+  inline void sum(const my_io_perf_struct& that) {
+    bytes.inc(that.bytes);
+    requests.inc(that.requests);
+
+    svc_time.inc(that.svc_time);
+    wait_time.inc(that.wait_time);
+
+    // In the unlikely case that two threads attempt to update the max
+    // value at the same time, only the first will succeed.  It's possible
+    // that the second thread would have set a larger max value, but we
+    // would rather error on the side of simplicity and avoid looping the
+    // compare-and-swap.
+    svc_time_max.set_max_maybe(that.svc_time);
+    wait_time_max.set_max_maybe(that.wait_time);
+
+    slow_ios.inc(that.slow_ios);
+  }
+
+  /* These assignments allow for races. That is OK. */
+  inline void set_maybe(const my_io_perf_struct& that) {
+    bytes.set_maybe(that.bytes);
+    requests.set_maybe(that.requests);
+    svc_time.set_maybe(that.svc_time);
+    svc_time_max.set_maybe(that.svc_time_max);
+    wait_time.set_maybe(that.wait_time);
+    wait_time_max.set_maybe(that.wait_time_max);
+    slow_ios.set_maybe(that.slow_ios);
+  }
+};
+typedef struct my_io_perf_atomic_struct my_io_perf_atomic_t;
+
+#ifdef	__cplusplus
+}
+#endif
+#endif

--- a/include/my_stacktrace.h
+++ b/include/my_stacktrace.h
@@ -53,7 +53,11 @@ void my_create_minidump(const char *name, HANDLE process, DWORD pid);
 
 void my_write_core(int sig);
 
+/* print stack traces for all threads */
+void my_pstack();
 
+#define abort_with_stack_traces() \
+  { my_pstack(); abort(); }
 
 /**
   Async-signal-safe utility functions used by signal handler routines.

--- a/mysys/stacktrace.cc
+++ b/mysys/stacktrace.cc
@@ -295,6 +295,63 @@ void my_write_core(int sig)
 #endif
 }
 
+/* print stack traces for all threads */
+void my_pstack()
+{
+#ifndef __WIN__
+  /* Print out the current stack trace */
+
+  static const int max_num_of_frames = 100;
+  void *stack_trace[max_num_of_frames];
+  int num_of_frames = backtrace(stack_trace, max_num_of_frames);
+  char **frames = backtrace_symbols(stack_trace, num_of_frames);
+  if (!frames)
+  {
+    my_safe_printf_stderr("backtrace_symbols didn't return valid data.");
+    return;
+  }
+
+  my_safe_printf_stderr("\nThe current stack traces:\n");
+  for (int i = 0; i < num_of_frames; ++i)
+  {
+    my_safe_printf_stderr("%s\n", frames[i]);
+  }
+  free(frames);
+
+  /* Print out all the stack traces */
+
+  char cmd[64];
+  pid_t pid = getpid();
+  sprintf(cmd, "pstack %d", pid);
+
+  my_safe_printf_stderr("\nAll stack traces from %s:\n", cmd);
+  FILE *fp = popen(cmd, "r");
+  if (!fp)
+  {
+    my_safe_printf_stderr("Couldn't run \"%s\" by popen.\n", cmd);
+    return;
+  }
+
+  static const size_t max_line_length = 4095;
+  char line_buf[max_line_length + 1];
+  uint output_lines = 0;
+  while (fgets(line_buf, max_line_length, fp))
+  {
+    my_write_stderr(line_buf, strlen(line_buf));
+    ++output_lines;
+  }
+  fclose(fp);
+  if (0 == output_lines)
+  {
+    my_safe_printf_stderr("No stack traces were printed out. "
+                          "This probably was because mysqld didn't have "
+                          "sufficient privileges, and/or some required system "
+                          "settings (suid_dumpable, ulimit, etc...) were not "
+                          "set correctly.\n");
+  }
+#endif  /* not __WIN__ */
+}
+
 #else /* _WIN32*/
 
 #include <dbghelp.h>

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -20,6 +20,8 @@ EXECUTE_PROCESS(
 STRING(REGEX MATCHALL "[^\n]+" ROCKSDB_LIB_SOURCES ${SCRIPT_OUTPUT})
 
 INCLUDE_DIRECTORIES(
+  ${CMAKE_SOURCE_DIR}/storage/innobase
+  ${CMAKE_SOURCE_DIR}/storage/innobase/include
   ${CMAKE_SOURCE_DIR}/rocksdb
   ${CMAKE_SOURCE_DIR}/rocksdb/include
   ${CMAKE_SOURCE_DIR}/rocksdb/third-party/gtest-1.7.0/fused-src

--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -22,7 +22,6 @@
 #include <vector>
 
 /* MySQL includes */
-#include <my_global.h>
 #include <mysql/plugin.h>
 
 /* MyRocks includes */

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8440,7 +8440,7 @@ int ha_rocksdb::index_end() {
     HA_EXIT_SUCCESS  OK
     other            HA_ERR error code (can be SE-specific)
 */
-int ha_rocksdb::truncate() {
+int ha_rocksdb::truncate(dd::Table *table_def) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(m_tbl_def != nullptr);
@@ -9267,7 +9267,8 @@ int ha_rocksdb::remove_rows(Rdb_tbl_def *const tbl) {
     HA_EXIT_SUCCESS  OK
     other            HA_ERR error code (cannot be SE-specific)
 */
-int ha_rocksdb::rename_table(const char *const from, const char *const to) {
+int ha_rocksdb::rename_table(const char *const from, const char *const to,
+                             const dd::Table *from_table_def, dd::Table *to_table_def) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(from != nullptr);

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -27,7 +27,6 @@
 
 /* MySQL header files */
 #include "./handler.h"   /* handler */
-#include "./my_global.h" /* ulonglong */
 #include "./sql_string.h"
 #include "./ut0counter.h"
 
@@ -764,7 +763,8 @@ public:
     return m_store_row_debug_checksums && (rand() % 100 < m_checksums_pct);
   }
 
-  int rename_table(const char *const from, const char *const to) override
+  int rename_table(const char *const from, const char *const to,
+                   const dd::Table *from_table_def, dd::Table *to_table_def) override
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
 
   int convert_blob_from_storage_format(my_core::Field_blob *const blob,
@@ -1157,7 +1157,7 @@ public:
       MY_ATTRIBUTE((__warn_unused_result__));
   int external_lock(THD *const thd, int lock_type) override
       MY_ATTRIBUTE((__warn_unused_result__));
-  int truncate() override MY_ATTRIBUTE((__warn_unused_result__));
+  int truncate(dd::Table *table_def) override MY_ATTRIBUTE((__warn_unused_result__));
 
   int reset() override {
     DBUG_ENTER_FUNC();

--- a/storage/rocksdb/rdb_index_merge.h
+++ b/storage/rocksdb/rdb_index_merge.h
@@ -19,7 +19,6 @@
 /* MySQL header files */
 #include "../sql/log.h"
 #include "./handler.h"   /* handler */
-#include "./my_global.h" /* ulonglong */
 
 /* C++ standard header files */
 #include <queue>

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -38,7 +38,7 @@ static const int64_t ONE_SECOND_IN_MICROSECS = 1000 * 1000;
 static const int64_t ONE_YEAR_IN_MICROSECS =
     ONE_SECOND_IN_MICROSECS * 60 * 60 * 24 * 365;
 
-Rdb_cond_var::Rdb_cond_var() { mysql_cond_init(0, &m_cond, nullptr); }
+Rdb_cond_var::Rdb_cond_var() { mysql_cond_init(0, &m_cond); }
 
 Rdb_cond_var::~Rdb_cond_var() { mysql_cond_destroy(&m_cond); }
 

--- a/storage/rocksdb/rdb_perf_context.h
+++ b/storage/rocksdb/rdb_perf_context.h
@@ -23,7 +23,6 @@
 
 /* MySQL header files */
 #include "./handler.h"
-#include <my_global.h>
 
 namespace myrocks {
 

--- a/storage/rocksdb/rdb_psi.h
+++ b/storage/rocksdb/rdb_psi.h
@@ -17,11 +17,6 @@
 #ifndef _rdb_psi_h_
 #define _rdb_psi_h_
 
-/* MySQL header files */
-#include <my_global.h>
-#include <my_pthread.h>
-#include <mysql/psi/psi.h>
-
 /* MyRocks header files */
 #include "./rdb_utils.h"
 

--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -43,7 +43,7 @@ void Rdb_thread::init(
     ) {
   DBUG_ASSERT(!m_run_once);
   mysql_mutex_init(stop_bg_psi_mutex_key, &m_signal_mutex, MY_MUTEX_INIT_FAST);
-  mysql_cond_init(stop_bg_psi_cond_key, &m_signal_cond, nullptr);
+  mysql_cond_init(stop_bg_psi_cond_key, &m_signal_cond);
 }
 
 void Rdb_thread::uninit() {

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -20,7 +20,6 @@
 #include <string>
 
 /* MySQL includes */
-#include "./my_global.h"
 #include <mysql/psi/mysql_table.h>
 #include <mysql/thread_pool_priv.h>
 

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -128,7 +128,7 @@ namespace myrocks {
   To increase the comprehension and readability of MyRocks codebase we'll use
   constants similar to ones from C standard (EXIT_SUCCESS and EXIT_FAILURE) to
   make sure that both failure and success paths are clearly identifiable. The
-  definitions of FALSE and TRUE come from <my_global.h>.
+  definitions of FALSE and TRUE come from <my_inttypes.h>.
 */
 #define HA_EXIT_SUCCESS FALSE
 #define HA_EXIT_FAILURE TRUE


### PR DESCRIPTION
Fixes for various build related issues:

 - Add exclusions to .gitignore.
 - Disable -Wundef for internal Facebook builds.
 - File my_global.h is no longer present in MySQL 8.0.
 - File my_pthread.h is no longer present in MySQL 8.0.
 - Need to tweak the include path to make sure that ut0counter.h is
   included.
 - Add abort_with_stack_traces() macro which implies adding my_pstack()
   definition and declaration.
 - mysql_cond_init no longer has a third parameter.
 - Adjust signature for rename_table() and truncate() interface methods.