### PR TITLE
Incremental work to make MyRocks build - part III

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <random>       // std::mt19937
 #include <string>
+#include <regex>
 
 #include "dd/object_id.h"      // dd::Object_id
 #include "discrete_interval.h" // Discrete_interval
@@ -2642,6 +2643,54 @@ public:
   virtual ~Handler_share() {}
 };
 
+class Regex_list_handler
+{
+ private:
+#if defined(HAVE_PSI_INTERFACE)
+  const PSI_rwlock_key& m_key;
+#endif
+
+  char m_delimiter;
+  std::string m_bad_pattern_str;
+  std::unique_ptr<const std::regex> m_pattern;
+
+  mutable mysql_rwlock_t m_rwlock;
+
+  Regex_list_handler(const Regex_list_handler& other)= delete;
+  Regex_list_handler& operator=(const Regex_list_handler& other)= delete;
+
+ public:
+#if defined(HAVE_PSI_INTERFACE)
+  Regex_list_handler(const PSI_rwlock_key& key,
+                     char delimiter= ',') :
+    m_key(key),
+#else
+  Regex_list_handler(char delimiter= ',') :
+#endif
+    m_delimiter(delimiter),
+    m_bad_pattern_str(""),
+    m_pattern(nullptr)
+  {
+    mysql_rwlock_init(key, &m_rwlock);
+  }
+
+  ~Regex_list_handler()
+  {
+    mysql_rwlock_destroy(&m_rwlock);
+  }
+
+  // Set the list of patterns
+  bool set_patterns(const std::string& patterns);
+
+  // See if a string matches at least one pattern
+  bool matches(const std::string& str) const;
+
+  // See the list of bad patterns
+  const std::string& bad_pattern() const
+  {
+    return m_bad_pattern_str;
+  }
+};
 
 /**
   Wrapper for struct ft_hints.

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7980,6 +7980,57 @@ ER_NOT_IMPLEMENTED_FOR_GEOGRAPHIC_SRS 22S00
 ER_ILLEGAL_PRIVILEGE_LEVEL
   eng "Illegal privilege level specified for %s"
 
+ER_KEYS_OUT_OF_ORDER
+  eng "Keys are out order during bulk load"
+
+ER_OVERLAPPING_KEYS
+  eng "Bulk load rows overlap existing rows"
+
+ER_REQUIRE_ROW_BINLOG_FORMAT
+  eng "Can't execute updates on master with binlog_format != ROW."
+
+ER_ISOLATION_MODE_NOT_SUPPORTED
+  eng "MyRocks supports only READ COMMITTED and REPEATABLE READ isolation levels. Please change from current isolation level %s"
+
+ER_ON_DUPLICATE_DISABLED
+  eng "When unique checking is disabled in MyRocks, INSERT,UPDATE,LOAD statements with clauses that update or replace the key (i.e. INSERT ON DUPLICATE KEY UPDATE, REPLACE) are not allowed. Query: %s"
+
+ER_UPDATES_WITH_CONSISTENT_SNAPSHOT
+  eng "Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT."
+
+ER_ROLLBACK_ONLY
+  eng "This transaction was rolled back and cannot be committed. Only supported operation is to roll it back, so all pending changes will be discarded. Please restart another transaction."
+
+ER_ROLLBACK_TO_SAVEPOINT
+  eng "MyRocks currently does not support ROLLBACK TO SAVEPOINT if modifying rows."
+
+ER_ISOLATION_LEVEL_WITH_CONSISTENT_SNAPSHOT
+  eng "Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine."
+
+ER_UNSUPPORTED_COLLATION
+  eng "Unsupported collation on string indexed column %s.%s Use binary collation (%s)."
+
+ER_METADATA_INCONSISTENCY
+  eng "Table '%s' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency. Please check if '%s.frm' exists, and try to restore it if it does not exist."
+
+ER_KEY_CREATE_DURING_ALTER
+  eng "MyRocks failed creating new key definitions during alter."
+
+ER_SK_POPULATE_DURING_ALTER
+  eng "MyRocks failed populating secondary key during alter."
+
+ER_CF_DIFFERENT
+  eng "Column family ('%s') flag (%d) is different from an existing flag (%d). Assign a new CF flag, or do not change existing CF flag."
+
+ER_PER_INDEX_CF_DEPRECATED
+  eng "The per-index column family option has been deprecated"
+
+ER_RDB_TTL_COL_FORMAT
+  eng "TTL column (%s) in MyRocks must be an unsigned non-null 64-bit integer, exist inside the table, and have an accompanying ttl duration."
+
+ER_RDB_TTL_DURATION_FORMAT
+  eng "TTL duration (%s) in MyRocks must be an unsigned non-null 64-bit integer."
+
 #
 #  End of 8.0 error messages.
 #

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -593,7 +593,8 @@ class ha_rocksdb : public my_core::handler {
       MY_ATTRIBUTE((__warn_unused_result__));
   bool is_blind_delete_enabled();
   bool skip_unique_check() const MY_ATTRIBUTE((__warn_unused_result__));
-  void set_force_skip_unique_check(bool skip) override;
+  // TODO: determine the replacement if any.
+  // void set_force_skip_unique_check(bool skip) override;
   bool commit_in_the_middle() MY_ATTRIBUTE((__warn_unused_result__));
   bool do_bulk_commit(Rdb_transaction *const tx)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
@@ -735,11 +736,14 @@ public:
   */
   ulong index_flags(uint inx, uint part, bool all_parts) const override;
 
+  // TODO: determine the replacement if any.
+  /*
   const Key_map *keys_to_use_for_scanning() override {
     DBUG_ENTER_FUNC();
 
     DBUG_RETURN(&key_map_full);
   }
+  */
 
   bool should_store_row_debug_checksums() const {
     return m_store_row_debug_checksums && (rand() % 100 < m_checksums_pct);
@@ -1170,15 +1174,18 @@ public:
                              enum thr_lock_type lock_type) override
       MY_ATTRIBUTE((__warn_unused_result__));
 
+  // TODO: determine the replacement if any.
+  /*
   bool register_query_cache_table(THD *const thd, char *const table_key,
                                      uint key_length,
                                      qc_engine_callback *const engine_callback,
                                      ulonglong *const engine_data) override {
     DBUG_ENTER_FUNC();
 
-    /* Currently, we don't support query cache */
+    // Currently, we don't support query cache.
     DBUG_RETURN(FALSE);
   }
+  */
 
   bool get_error_message(const int error, String *const buf) override
       MY_ATTRIBUTE((__nonnull__));

--- a/storage/rocksdb/rdb_index_merge.h
+++ b/storage/rocksdb/rdb_index_merge.h
@@ -19,6 +19,7 @@
 /* MySQL header files */
 #include "../sql/log.h"
 #include "./handler.h"   /* handler */
+#include "sql/sql_thd_internal_api.h"
 
 /* C++ standard header files */
 #include <queue>

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -73,7 +73,7 @@ Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
 
   if (timeout_micros < 0)
     timeout_micros = ONE_YEAR_IN_MICROSECS;
-  set_timespec_nsec(wait_timeout, timeout_micros * 1000);
+  set_timespec_nsec(&wait_timeout, timeout_micros * 1000);
 
 #ifndef STANDALONE_UNITTEST
   PSI_stage_info old_stage;

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -26,6 +26,7 @@
 /* MySQL header files */
 #include "./my_sys.h"
 #include "mysql/plugin.h"
+#include "sql/current_thd.h"
 
 /* RocksDB header files */
 #include "rocksdb/utilities/transaction_db_mutex.h"

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -24,6 +24,7 @@
 #include "../sql/log.h"
 #include "./my_stacktrace.h"
 #include "./sql_string.h"
+#include "./mysqld.h"
 
 /* RocksDB header files */
 #include "rocksdb/slice.h"


### PR DESCRIPTION
List of fixes:

 - Add class Regex_list_handler to sql/handler.h. This is something we
   added in past.
 - Adjust signatures for thd_mark_transaction_to_rollback(),
   thd_binlog_format(), thd_binlog_filter_ok().
 - Adjust to changes in my_malloc() signature by adding
   PSI_NOT_INSTRUMENTED as a first parameter. We should possibly add
   in future a MyRocks specific key to isolate our allocations.
 - Add extern CHARSET_INFO my_charset_utf1* because they're no longer
   part of include/m_ctype.h.
 - Given that check_field_name_match() function is gone then replace the
   comparison with a pattern MySQL 8.0 is using.
 - levels_for_order member variable of CHARSET_INFO is gone. Take the
   default code path. This needs to be investigated further.
 - Add various MyRocks error codes to sql/share/errmsg-utf8.txt. This is
   something we added in past.
 - Comment out set_force_skip_unique_check(), keys_to_use_for_scanning(),
   register_query_cache_table(). Needs to be determined later if any
   other changes are needed.
 - Add missing header inclusions.