### PR TITLE
Incremental work to make MyRocks build - part IV

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -206,24 +206,25 @@ typedef int (*mysql_show_var_func)(MYSQL_THD, struct st_mysql_show_var*, char *)
 */
 
 
-#define PLUGIN_VAR_BOOL         0x0001
-#define PLUGIN_VAR_INT          0x0002
-#define PLUGIN_VAR_LONG         0x0003
-#define PLUGIN_VAR_LONGLONG     0x0004
-#define PLUGIN_VAR_STR          0x0005
-#define PLUGIN_VAR_ENUM         0x0006
-#define PLUGIN_VAR_SET          0x0007
-#define PLUGIN_VAR_DOUBLE       0x0008
-#define PLUGIN_VAR_UNSIGNED     0x0080
-#define PLUGIN_VAR_THDLOCAL     0x0100 /* Variable is per-connection */
-#define PLUGIN_VAR_READONLY     0x0200 /* Server variable is read only */
-#define PLUGIN_VAR_NOSYSVAR     0x0400 /* Not a server variable */
-#define PLUGIN_VAR_NOCMDOPT     0x0800 /* Not a command line option */
-#define PLUGIN_VAR_NOCMDARG     0x1000 /* No argument for cmd line */
-#define PLUGIN_VAR_RQCMDARG     0x0000 /* Argument required for cmd line */
-#define PLUGIN_VAR_OPCMDARG     0x2000 /* Argument optional for cmd line */
-#define PLUGIN_VAR_NODEFAULT    0x4000 /* SET DEFAULT is prohibited */
-#define PLUGIN_VAR_MEMALLOC     0x8000 /* String needs memory allocated */
+#define PLUGIN_VAR_BOOL         0x00001
+#define PLUGIN_VAR_INT          0x00002
+#define PLUGIN_VAR_LONG         0x00003
+#define PLUGIN_VAR_LONGLONG     0x00004
+#define PLUGIN_VAR_STR          0x00005
+#define PLUGIN_VAR_ENUM         0x00006
+#define PLUGIN_VAR_SET          0x00007
+#define PLUGIN_VAR_DOUBLE       0x00008
+#define PLUGIN_VAR_UNSIGNED     0x00080
+#define PLUGIN_VAR_THDLOCAL     0x00100 /* Variable is per-connection */
+#define PLUGIN_VAR_READONLY     0x00200 /* Server variable is read only */
+#define PLUGIN_VAR_NOSYSVAR     0x00400 /* Not a server variable */
+#define PLUGIN_VAR_NOCMDOPT     0x00800 /* Not a command line option */
+#define PLUGIN_VAR_NOCMDARG     0x01000 /* No argument for cmd line */
+#define PLUGIN_VAR_RQCMDARG     0x00000 /* Argument required for cmd line */
+#define PLUGIN_VAR_OPCMDARG     0x02000 /* Argument optional for cmd line */
+#define PLUGIN_VAR_NODEFAULT    0x04000 /* SET DEFAULT is prohibited */
+#define PLUGIN_VAR_MEMALLOC     0x08000 /* String needs memory allocated */
+#define PLUGIN_VAR_ALLOCATED    0x10000 /* memory for string has been allocated*/
 
 struct st_mysql_sys_var;
 struct st_mysql_value;
@@ -277,7 +278,7 @@ typedef void (*mysql_var_update_func)(MYSQL_THD thd,
         (PLUGIN_VAR_READONLY | PLUGIN_VAR_NOSYSVAR | \
          PLUGIN_VAR_NOCMDOPT | PLUGIN_VAR_NOCMDARG | \
          PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC | \
-         PLUGIN_VAR_NODEFAULT)
+         PLUGIN_VAR_NODEFAULT | PLUGIN_VAR_ALLOCATED)
 
 #define MYSQL_PLUGIN_VAR_HEADER \
   int flags;                    \
@@ -597,6 +598,12 @@ struct st_mysql_value
   int (*is_unsigned)(struct st_mysql_value *);
 };
 
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
 
 /*************************************************************************
   Miscellaneous functions for plugin implementors

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -77,6 +77,12 @@ struct st_mysql_value
   int (*val_int)(struct st_mysql_value *, long long *intbuf);
   int (*is_unsigned)(struct st_mysql_value *);
 };
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
 int thd_in_lock_tables(const void* thd);
 int thd_tablespace_op(const void* thd);
 long long thd_test_options(const void* thd, long long test_options);

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -77,6 +77,12 @@ struct st_mysql_value
   int (*val_int)(struct st_mysql_value *, long long *intbuf);
   int (*is_unsigned)(struct st_mysql_value *);
 };
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
 int thd_in_lock_tables(const void* thd);
 int thd_tablespace_op(const void* thd);
 long long thd_test_options(const void* thd, long long test_options);

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -77,6 +77,12 @@ struct st_mysql_value
   int (*val_int)(struct st_mysql_value *, long long *intbuf);
   int (*is_unsigned)(struct st_mysql_value *);
 };
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
 int thd_in_lock_tables(const void* thd);
 int thd_tablespace_op(const void* thd);
 long long thd_test_options(const void* thd, long long test_options);

--- a/include/mysql/plugin_keyring.h.pp
+++ b/include/mysql/plugin_keyring.h.pp
@@ -77,6 +77,12 @@ struct st_mysql_value
   int (*val_int)(struct st_mysql_value *, long long *intbuf);
   int (*is_unsigned)(struct st_mysql_value *);
 };
+struct st_slave_gtid_info
+{
+  unsigned int id;
+  const char* db;
+  const char* gtid;
+};
 int thd_in_lock_tables(const void* thd);
 int thd_tablespace_op(const void* thd);
 long long thd_test_options(const void* thd, long long test_options);

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3603,9 +3603,10 @@ static bool plugin_var_memalloc_global_update(THD *thd,
   DBUG_EXECUTE_IF("simulate_bug_20292712", my_sleep(1000););
   DBUG_ENTER("plugin_var_memalloc_global_update");
 
-  if (value && !(value= my_strdup(key_memory_global_system_variables,
-                                  value, MYF(MY_WME))))
-    DBUG_RETURN(true);
+  if (!(var->flags & PLUGIN_VAR_ALLOCATED)) {
+    if (value && !(value= my_strdup(value, MYF(MY_WME))))
+      DBUG_RETURN(true);
+  }
 
   var->update(thd, var, (void **) dest, (const void *) &value);
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -222,7 +222,7 @@ const char *const RDB_TTL_COL_QUALIFIER = "ttl_col";
 
   The reason behind the cast issue is the lack of unsigned int support in Java.
 */
-#define MAX_RATE_LIMITER_BYTES_PER_SEC static_cast<uint64_t>(LONGLONG_MAX)
+#define MAX_RATE_LIMITER_BYTES_PER_SEC static_cast<uint64_t>(LLONG_MAX)
 
 /*
   Hidden PK column (for tables with no primary key) is a longlong (aka 8 bytes).

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1014,8 +1014,7 @@ private:
   int put(Rdb_tbl_def *const key_descr, const bool &lock = true);
 
   /* Helper functions to be passed to my_core::HASH object */
-  static const uchar *get_hash_key(Rdb_tbl_def *const rec, size_t *const length,
-                                   bool not_used MY_ATTRIBUTE((unused)));
+  static const uchar *get_hash_key(const uchar *arg, size_t *length);
   static void free_hash_elem(void *const data);
 
   bool validate_schemas();


### PR DESCRIPTION
List of fixes:

 - Definition of LONGLONG_MAX is obsolete. Use LLONG_MAX from <limits.h>.
 - Data dictionary implementation is new. Comment out
   Rdb_validate_tbls::check_frm_file(). It needs to be understood how
   this functionality will be replaced in 8.0.
 - my_hash_get_key is removed. Adjust code to use new signatures.
 - Port over code to handle PLUGIN_VAR_ALLOCATED.
 - Port over struct st_slave_gtid_info.
 - Port over String timeout_message.
 - Adjust to signature changes in <xa.h> and use accessor methods.