### PR TITLE
Shorten the temporary directory path in Sandcastle

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1667,7 +1667,8 @@ sub command_line_setup {
   {
     $opt_tmpdir=       "$opt_vardir/tmp" unless $opt_tmpdir;
 
-    if (check_socket_path_length("$opt_tmpdir/mysql_testsocket.sock",$opt_parallel))
+    if (defined $ENV{SANDCASTLE} ||
+        check_socket_path_length("$opt_tmpdir/mysql_testsocket.sock",$opt_parallel))
     {
       mtr_report("Too long tmpdir path '$opt_tmpdir'",
 		 " creating a shorter one...");


### PR DESCRIPTION
Always shorten the path when tests are running in Sandcastle
environment. This will hopefully fix the problems caused by the depth of
directory structure.